### PR TITLE
Bump to the latest releases

### DIFF
--- a/demo/requirements.txt
+++ b/demo/requirements.txt
@@ -1,10 +1,10 @@
 # Core modules (mandatory)
-jupyterlite-core==0.2.2
-jupyterlab~=4.0.10
-notebook~=7.0.6
+jupyterlite-core==0.2.3
+jupyterlab~=4.0.11
+notebook~=7.0.7
 
 # Python kernel (optional)
-jupyterlite-pyodide-kernel==0.2.0
+jupyterlite-pyodide-kernel==0.2.1
 
 # Language support (optional)
 jupyterlab-language-pack-fr-FR


### PR DESCRIPTION
Bump:

- `jupyterlab`
- `notebook`
- `jupyterlite-core`
- `jupyterlite-pyodide-kernel`